### PR TITLE
Add core24 to the workflow matrix

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -8,6 +8,12 @@ on:
     - master
   workflow_dispatch:
 
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-image:
     runs-on: ubuntu-latest
@@ -27,6 +33,9 @@ jobs:
         - base: core22
           base_os: jammy
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
+        - base: core24
+          base_os: noble
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -34,7 +43,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: diddledani/snapcraft
+        images:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch,prefix=${{ matrix.cfg.base }}-
           type=ref,event=pr,prefix=${{ matrix.cfg.base }}-
@@ -45,7 +54,7 @@ jobs:
         labels: |
           org.opencontainers.image.title=Snapcraft for ${{ matrix.cfg.base }} builds
           org.opencontainers.image.description=Image of Snapcraft for building projects targeting the ${{ matrix.cfg.base }} base snap.
-          org.opencontainers.image.authors=diddledani@ubuntu.com
+          org.opencontainers.image.authors=massimiliano.girardi@canonical.com
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
@@ -53,8 +62,9 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v6
       with:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -6,11 +6,9 @@ on:
   push:
     branches:
     - master
-    - core24_support
   workflow_dispatch:
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -22,19 +22,19 @@ jobs:
         cfg:
         - base: core
           base_os: xenial
-          platforms: linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core18
           base_os: bionic
-          platforms: linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core20
           base_os: focal
-          platforms: linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core22
           base_os: jammy
-          platforms: linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core24
           base_os: noble
-          platforms: linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,19 +23,19 @@ jobs:
         cfg:
         - base: core
           base_os: xenial
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/arm64,linux/arm/v7
         - base: core18
           base_os: bionic
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/arm64,linux/arm/v7
         - base: core20
           base_os: focal
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/arm64,linux/arm/v7
         - base: core22
           base_os: jammy
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/arm64,linux/arm/v7
         - base: core24
           base_os: noble
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/arm64,linux/arm/v7
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -59,10 +59,11 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         # see https://github.com/tonistiigi/binfmt/issues/215
-        image: tonistiigi/binfmt:master
+        # also see: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782
+        image: ${{ matrix.cfg.base_os != 'jammy' && 'tonistiigi/binfmt:master' || 'tonistiigi/binfmt:qemu-v7.0.0-28' }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    - name: Login to DockerHub
+    - name: Login to ghio
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
     - master
+    - core24_support
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,19 +23,19 @@ jobs:
         cfg:
         - base: core
           base_os: xenial
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core18
           base_os: bionic
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core20
           base_os: focal
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core22
           base_os: jammy
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le #,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core24
           base_os: noble
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -57,6 +57,9 @@ jobs:
           org.opencontainers.image.authors=massimiliano.girardi@canonical.com
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see https://github.com/tonistiigi/binfmt/issues/215
+        image: tonistiigi/binfmt:master
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        PLATFORMS=(linux/arm/v7 linux/arm64) # linux/s390x)
+        PLATFORMS=(linux/amd64 linux/arm/v7 linux/arm64) # linux/s390x)
         BASES=(core core18 core20 core22 core24)
 
         BUILD_MATRIX=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        PLATFORMS=(linux/amd64 linux/arm/v7 linux/arm64) # linux/s390x)
+        PLATFORMS=(linux/arm/v7 linux/arm64) # linux/s390x)
         BASES=(core core18 core20 core22 core24)
 
         BUILD_MATRIX=
@@ -63,7 +63,7 @@ jobs:
 
   build:
     name: Build PR
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.base.os != 'jammy' && 'ubuntu-latest' || 'ubuntu-22.04' }}
     needs: generate-matrix
     strategy:
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         # see https://github.com/tonistiigi/binfmt/issues/215
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
+        image: ${{ matrix.base.os != 'jammy' && 'tonistiigi/binfmt:master' || 'tonistiigi/binfmt:qemu-v7.0.0-28' }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,8 @@ jobs:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        #PLATFORMS=(linux/arm/v7 linux/arm64) # linux/s390x)
-        PLATFORMS=(linux/arm/v7)
-        #BASES=(core core18 core20 core22 core24)
-        BASES=(core22 core24)
+        PLATFORMS=(linux/arm/v7 linux/arm64) # linux/s390x)
+        BASES=(core core18 core20 core22 core24)
 
         BUILD_MATRIX=
         DOCKER_TEST_MATRIX=
@@ -77,6 +75,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         # see https://github.com/tonistiigi/binfmt/issues/215
+        # also see: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782
         image: ${{ matrix.base.os != 'jammy' && 'tonistiigi/binfmt:master' || 'tonistiigi/binfmt:qemu-v7.0.0-28' }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
         file: ./Dockerfile
         platforms: ${{ matrix.platform }}
         tags: test-image
+        no-cache: true
         push: false
         outputs: type=docker,dest=test-image.tar
         build-args:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,15 @@ jobs:
     outputs:
       build_matrix: ${{ steps.matrix.outputs.build_matrix }}
       docker_test_matrix: ${{ steps.matrix.outputs.docker_test_matrix }}
-      podman_test_matrix: ${{ steps.matrix.outputs.podman_test_matrix }}
     steps:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        PLATFORMS=(linux/386 linux/amd64 linux/arm/v7 linux/arm64 linux/ppc64le) # linux/s390x)
-        BASES=(core core18 core20 core22)
+        PLATFORMS=(linux/amd64 linux/arm/v7 linux/arm64) # linux/s390x)
+        BASES=(core core18 core20 core22 core24)
 
         BUILD_MATRIX=
         DOCKER_TEST_MATRIX=
-        PODMAN_TEST_MATRIX=
 
         for base in ${BASES[@]}; do
           channel=latest/stable
@@ -42,6 +40,9 @@ jobs:
             core22)
               os=jammy
               ;;
+            core24)
+              os=noble
+              ;;
           esac
 
           for platform in ${PLATFORMS[@]}; do
@@ -55,13 +56,11 @@ jobs:
             DOCKER_TEST_MATRIX="${DOCKER_TEST_MATRIX:+$DOCKER_TEST_MATRIX,}{\"platform\":\"$platform\",\"channel\":\"$channel\",\"base\":\"$base\",\"runner\":\"$runner\",\"experimental\":$experimental}"
           done
 
-          PODMAN_TEST_MATRIX="${PODMAN_TEST_MATRIX:+$PODMAN_TEST_MATRIX,}{\"platform\":\"linux/amd64\",\"channel\":\"$channel\",\"base\":\"$base\",\"runner\":\"$runner\"}"
         done
 
         echo "build_matrix={\"include\":[$BUILD_MATRIX]}" >> $GITHUB_OUTPUT
         echo "docker_test_matrix={\"include\":[$DOCKER_TEST_MATRIX]}" >> $GITHUB_OUTPUT
-        echo "podman_test_matrix={\"include\":[$PODMAN_TEST_MATRIX]}" >> $GITHUB_OUTPUT
-      
+
   build:
     name: Build PR
     runs-on: ubuntu-latest
@@ -73,6 +72,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see https://github.com/tonistiigi/binfmt/issues/215
+        image: tonistiigi/binfmt:master
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build
@@ -132,33 +134,6 @@ jobs:
           --workdir "/data" \
           test-image snapcraft
 
-  test-build-snap-podman:
-    name: Test Build Snap with Podman
-    runs-on: ${{matrix.runner}}
-    needs: [ generate-matrix, build ]
-    continue-on-error: true
-    strategy:
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.podman_test_matrix) }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Load container image
-      id: load_image
-      run: |
-        echo image_name="$(echo "${{matrix.base}}-${{matrix.platform}}.tar" | sed 's|/|_|g')" >> $GITHUB_OUTPUT
-    - uses: actions/download-artifact@v4
-      with:
-        name: ${{ steps.load_image.outputs.image_name }}
-        path: ./artifacts
-    - name: Test build a Snap
-      id: build
-      run: |
-        sudo podman image load -i ./artifacts/test-image.tar
-        sudo podman run --rm --tty --privileged --systemd always \
-          --env USE_SNAPCRAFT_CHANNEL="${{ matrix.channel }}" \
-          --volume "$GITHUB_WORKSPACE/tests/${{ matrix.base }}":"/data" \
-          --workdir "/data" \
-          localhost/latest snapcraft
 
   test-set-channel-docker:
     name: Test Set Channel with Docker
@@ -208,45 +183,6 @@ jobs:
 
         [ -n "$CHANNEL" ] && [ "$CHANNEL" = "$USE_SNAPCRAFT_CHANNEL" ]
 
-  test-set-channel-podman:
-    name: Test Set Channel with Podman
-    runs-on: ${{matrix.runner}}
-    needs: [ generate-matrix, build ]
-    continue-on-error: true
-    strategy:
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.podman_test_matrix) }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Load container image
-      id: load_image
-      run: |
-        echo image_name="$(echo "${{matrix.base}}-${{matrix.platform}}.tar" | sed 's|/|_|g')" >> $GITHUB_OUTPUT
-    - uses: actions/download-artifact@v4
-      with:
-        name: ${{ steps.load_image.outputs.image_name }}
-        path: ./artifacts
-    - name: Test changing channel
-      run: |
-        sudo podman image load -i ./artifacts/test-image.tar
-
-        USE_SNAPCRAFT_CHANNEL="$(echo -n ${{ matrix.channel }} | sed -e 's/stable/candidate/')"
-
-        echo ::group
-        sudo podman run --rm --tty --privileged --systemd always \
-          --env USE_SNAPCRAFT_CHANNEL="$USE_SNAPCRAFT_CHANNEL" \
-          localhost/latest snap info snapcraft --color=never 2>&1 | tee output.txt
-        echo ::endgroup
-
-        CHANNEL="$(cat output.txt | \
-          tr '\r\n' '\n' | \
-          awk 'BEGIN { FS = ":" }; /^tracking:/ { gsub(/ /, "", $2); print $2 }'
-        )"
-
-        echo "Snapcraft channel in use: $CHANNEL"
-
-        [ -n "$CHANNEL" ] && [ "$CHANNEL" = "$USE_SNAPCRAFT_CHANNEL" ]
-
   test-failure-docker:
     name: Test Failures with Docker (expected)
     runs-on: ${{matrix.runner}}
@@ -284,39 +220,6 @@ jobs:
           --volume "$GITHUB_WORKSPACE/tests/${{ matrix.base }}":"/data" \
           --workdir "/data" \
           test-image snapcraft
-        then
-          echo "Snapcraft build should have failed"
-          exit 1
-        fi
-
-  test-failure-podman:
-    name: Test Failures with Podman (expected)
-    runs-on: ${{matrix.runner}}
-    needs: [ generate-matrix, build ]
-    continue-on-error: true
-    strategy:
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.podman_test_matrix) }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Load container image
-      id: load_image
-      run: |
-        echo image_name="$(echo "${{matrix.base}}-${{matrix.platform}}.tar" | sed 's|/|_|g')" >> $GITHUB_OUTPUT
-    - uses: actions/download-artifact@v4
-      with:
-        name: ${{ steps.load_image.outputs.image_name }}
-        path: ./artifacts
-    - name: Test failure to build a Snap
-      id: build
-      run: |
-        sudo podman image load -i ./artifacts/test-image.tar
-        sed -Ei 's/command: bin\/hello/command: bin\/does-not-exist/' tests/${{ matrix.base }}/snap/snapcraft.yaml
-        if sudo podman run --rm --tty --privileged --systemd always \
-          --env USE_SNAPCRAFT_CHANNEL="${{ matrix.channel }}" \
-          --volume "$GITHUB_WORKSPACE/tests/${{ matrix.base }}":"/data" \
-          --workdir "/data" \
-          localhost/latest snapcraft
         then
           echo "Snapcraft build should have failed"
           exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,10 @@ jobs:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        PLATFORMS=(linux/arm/v7 linux/arm64) # linux/s390x)
-        BASES=(core core18 core20 core22 core24)
+        #PLATFORMS=(linux/arm/v7 linux/arm64) # linux/s390x)
+        PLATFORMS=(linux/arm/v7)
+        #BASES=(core core18 core20 core22 core24)
+        BASES=(core22 core24)
 
         BUILD_MATRIX=
         DOCKER_TEST_MATRIX=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-matrix
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.build_matrix) }}
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
     needs: [ generate-matrix, build ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.docker_test_matrix) }}
     steps:
     - name: Checkout
@@ -142,6 +143,7 @@ jobs:
     needs: [ generate-matrix, build ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.docker_test_matrix) }}
     steps:
     - name: Checkout
@@ -190,6 +192,7 @@ jobs:
     needs: [ generate-matrix, build ]
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.docker_test_matrix) }}
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see https://github.com/tonistiigi/binfmt/issues/215
+        image: 'tonistiigi/binfmt:master'
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Enable Docker experimental
@@ -150,6 +153,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see https://github.com/tonistiigi/binfmt/issues/215
+        image: 'tonistiigi/binfmt:master'
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Enable Docker experimental
@@ -199,6 +205,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see https://github.com/tonistiigi/binfmt/issues/215
+        image: 'tonistiigi/binfmt:master'
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Enable Docker experimental

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,12 @@ name: Build and Test
 
 on:
   pull_request:
+    paths:
+      - Dockerfile
+      - entrypoint.sh
+      - tests/**
+      - systemd-detect-virt
+      - .github/workflows/test.yml
 
 jobs:
   generate-matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
   build:
     name: Build PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: generate-matrix
     strategy:
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
       with:
         # see https://github.com/tonistiigi/binfmt/issues/215
-        image: tonistiigi/binfmt:master
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN mksquashfs /snap/snapd/current /snapd.snap
 
 
 # Prepare the filesystem to copy into a blank image
-FROM ubuntu:${BASE_OS} as base
+FROM ubuntu:${BASE_OS} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -105,7 +105,7 @@ RUN rm -vf /usr/share/systemd/tmp.mount
 RUN echo ShowStatus=no >> /etc/systemd/system.conf
 
 # disable ondemand.service
-RUN systemctl disable ondemand.service
+RUN  if [ "$BASE_OS" != "noble" ]; then systemctl disable ondemand.service; fi
 
 # set basic.target as default
 RUN systemctl set-default basic.target

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_OS=xenial
 # Download and repack snapd with a replacement squashfs-tools to
 # fix a bug with mksquashfs when packing a built snap.
 # See: https://bugs.launchpad.net/snapd/+bug/1733598
-FROM ubuntu:xenial as snapd
+FROM ubuntu:xenial AS snapd
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LDFLAGS=-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN rm -vf /usr/share/systemd/tmp.mount
 RUN echo ShowStatus=no >> /etc/systemd/system.conf
 
 # disable ondemand.service
-RUN  systemctl disable ondemand.service || true
+RUN systemctl disable ondemand.service || true
 
 # set basic.target as default
 RUN systemctl set-default basic.target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,5 @@
 ARG BASE_OS=xenial
 
-# Download and repack snapd with a replacement squashfs-tools to
-# fix a bug with mksquashfs when packing a built snap.
-# See: https://bugs.launchpad.net/snapd/+bug/1733598
-FROM ubuntu:xenial AS snapd
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV LDFLAGS=-static
-
-# Run apt-get commands together to always ensure apt-get update is run
-# before using apt-get install to avoid issues with stale apt caches.
-RUN apt-get update -qq && \
-	apt-get dist-upgrade --yes && \
-	apt-get install --yes -qq --no-install-recommends \
-		fuse \
-		gnupg \
-		python3 \
-		snapd \
-		sudo \
-		systemd \
-		build-essential \
-		git \
-		help2man \
-		zlib1g-dev \
-		liblz4-dev \
-		liblzma-dev \
-		liblzo2-dev
-
-# Fetch and compile squashfs-tools
-RUN git clone https://github.com/plougher/squashfs-tools.git
-RUN cd squashfs-tools && \
-	git checkout 4.5.1 && \
-	sed -Ei 's/#(XZ_SUPPORT.*)/\1/' squashfs-tools/Makefile && \
-	sed -Ei 's/#(LZO_SUPPORT.*)/\1/' squashfs-tools/Makefile && \
-	sed -Ei 's/#(LZ4_SUPPORT.*)/\1/' squashfs-tools/Makefile && \
-	sed -Ei 's|(INSTALL_PREFIX = ).*|\1 /usr|' squashfs-tools/Makefile && \
-	sed -Ei 's/\$\(INSTALL_DIR\)/$(DESTDIR)$(INSTALL_DIR)/g' squashfs-tools/Makefile && \
-	cd squashfs-tools && \
-	make -j$(nproc) && \
-	make install
-
-# Download and unpack snapd
-RUN mkdir -p /snap/snapd/current
-RUN snap download snapd
-RUN unsquashfs -f -d /snap/snapd/current snapd_*.snap
-
-# Replace mksquashfs and unsqusahfs with our own
-RUN cp /usr/bin/mksquashfs /snap/snapd/current/usr/bin
-RUN cp /usr/bin/unsquashfs /snap/snapd/current/usr/bin
-
-# Repack snapd
-RUN mksquashfs /snap/snapd/current /snapd.snap
-
-
 # Prepare the filesystem to copy into a blank image
 FROM ubuntu:${BASE_OS} AS base
 
@@ -124,9 +71,6 @@ ENV container=docker \
 
 # Copy the entire filesystem from the base image
 COPY --from=base / /
-
-# Copy the snapd snap from the snapd image
-COPY --from=snapd /snapd.snap /snapd.snap
 
 # Add our entrypoint
 ADD entrypoint.sh /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN rm -vf /usr/share/systemd/tmp.mount
 RUN echo ShowStatus=no >> /etc/systemd/system.conf
 
 # disable ondemand.service
-RUN  if [ "$BASE_OS" != "noble" ]; then systemctl disable ondemand.service; fi
+RUN  systemctl disable ondemand.service || true
 
 # set basic.target as default
 RUN systemctl set-default basic.target

--- a/README.md
+++ b/README.md
@@ -1,64 +1,67 @@
-These container images start systemd and execute the command line passed on invokation. The commandline is executed as an interactive systemd service unit.
+Usage
+-----
 
-*IMPORTANT* These container images are *NOT* compatible with Docker provided through the Snap Store due to confinement rules applied to the dockerd interfering with (preventing) our container's execution.
+These containers are meant to be used with the action:
+https://github.com/Hook25/snapcraft-multiarch-action.
 
-You may override the entrypoint with the `--entrypoint` parameter if you need to run the container without starting systemd. Or you may drop to a shell with systemd running by setting the command to `bash`.
+These container images start systemd and execute the command line passed on
+invokation. The commandline is executed as an interactive systemd service unit.
+
+*IMPORTANT* These container images are *NOT* compatible with Docker provided
+through the Snap Store due to confinement rules applied to the dockerd
+interfering with (preventing) our container's execution.
+
+You may override the entrypoint with the `--entrypoint` parameter if you need
+to run the container without starting systemd. Or you may drop to a shell with
+systemd running by setting the command to `bash`.
 
 These container images require you to pass `--privileged`.
 
 Notes
 -----
-For builds against `core` the version of Systemd included in Ubuntu Xenial, and thus included in the `core` container images, is not compatible with cgroups version 2. This causes the `core` container image to fail to finish starting on newer distros. On systems that use cgroups2 you might _still_ be able to run the `core` container images by adding `--tmpfs /sys/fs/cgroup` to the docker or podman command line.
+For builds against `core` the version of Systemd included in Ubuntu Xenial,
+and thus included in the `core` container images, is not compatible with
+cgroups version 2. This causes the `core` container image to fail to finish
+starting on newer distros. On systems that use cgroups2 you might _still_ be
+able to run the `core` container images by adding `--tmpfs /sys/fs/cgroup` to
+the docker or podman command line.
 
-Previous instructions, based on earlier iterations of the container images, required you to create
-and use an AppArmor namespace - this is not necessary any more.  That is, you no-longer need to create a separate AppArmor namespace directory at
-`/sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft` and you can drop the
-`--security-opt apparmor=":docker-snapcraft:unconfined"` parameter from your `docker` command line.
+Previous instructions, based on earlier iterations of the container images,
+required you to create
+and use an AppArmor namespace - this is not necessary any more.  That is, you
+no-longer need to create a separate AppArmor namespace directory at
+`/sys/kernel/security/apparmor/policy/namespaces/docker-snapcraft` and you can
+drop the
+`--security-opt apparmor=":docker-snapcraft:unconfined"` parameter from your
+`docker` command line.
 
 Running snapcraft
 -----------------
 
-Running without specifying a command will run `snapcraft` without any parameters:
+Running without specifying a command will run `snapcraft` without any
+parameters:
 
 ```bash
-docker run --rm -it --privileged -v $PWD:/data -w /data diddledani/snapcraft:core22
+docker run --rm -it --privileged -v $PWD:/data -w /data ghcr.io/hook25/snapcraft-container:core24
 ```
 
-To run with parameters, specify `snapcraft [...params]` when creating the container:
+To run with parameters, specify `snapcraft [...params]` when creating the
+container:
 
 ```bash
-docker run --rm -it --privileged -v $PWD:/data -w /data diddledani/snapcraft:core22 snapcraft stage --enable-experimental-package-repositories
+docker run --rm -it --privileged -v $PWD:/data -w /data ghcr.io/hook25/snapcraft-container:core24 snapcraft stage --enable-experimental-package-repositories
 ```
 
 Drop to a shell with systemd running
 ------------------------------------
 
 ```bash
-docker run --rm -it --privileged -v $PWD:/data -w /data diddledani/snapcraft:core22 bash
+docker run --rm -it --privileged -v $PWD:/data -w /data ghcr.io/hook25/snapcraft-container:core24 bash
 ```
 
 Drop to a shell without starting systemd
 ----------------------------------------
 
 ```bash
-docker run --rm -it --privileged -v $PWD:/data -w /data --entrypoint bash diddledani/snapcraft:core22
+docker run --rm -it --privileged -v $PWD:/data -w /data --entrypoint bash ghcr.io/hook25/snapcraft-container:core24
 ```
-
-*Experimental* support for running through Podman
--------------------------------------------------
-
-These containers _should_ now be compatible with Podman, but have
-yet to receive much in the way of testing and validation. With the
-proviso that this is highly experimental for these images, you can
-try to run the build through Podman with:
-
-```bash
-sudo podman run --rm -it --privileged --systemd always -v $PWD:/data -w /data docker.io/diddledani/snapcraft:core22
-```
-
-Running through `sudo` seems to be a requirement to allow mounting
-squashfs filesystems, and we still need `--privileged` the same as
-when we are running through Docker. We also need to add the
-`--systemd always` flag to get Podman to set up the runtime
-environment appropriately for running Systemd inside the new
-container instance.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,6 @@ Wants=snapd.seeded.service
 After=snapd.service snapd.socket snapd.seeded.service
 
 [Service]
-ExecStartPre=/bin/bash -c '/usr/bin/snap install /snapd.snap --dangerous < /dev/null'
 ExecStartPre=/bin/bash -c '/usr/bin/snap install snapcraft --classic --channel $USE_SNAPCRAFT_CHANNEL < /dev/null'
 ExecStart=/usr/local/bin/docker_commandline.sh
 Environment="SNAPPY_LAUNCHER_INSIDE_TESTS=true"

--- a/tests/core24/hello.c
+++ b/tests/core24/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Hello world\n");
+    return 0;
+}

--- a/tests/core24/meson.build
+++ b/tests/core24/meson.build
@@ -1,0 +1,3 @@
+project('test-build-action', 'c', version : '0.1')
+
+executable('hello', 'hello.c', install : true)

--- a/tests/core24/snap/snapcraft.yaml
+++ b/tests/core24/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
-name: test-build-action-core22
-base: core22
+name: test-build-action-core24
+base: core24
 version: '0.1'
 summary: A simple test snap used to test the Github build action
 description: ...

--- a/tests/core24/snap/snapcraft.yaml
+++ b/tests/core24/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: test-build-action-core22
+base: core22
+version: '0.1'
+summary: A simple test snap used to test the Github build action
+description: ...
+
+grade: devel
+confinement: strict
+
+apps:
+  test-build-action:
+    command: bin/hello
+
+parts:
+  build:
+    plugin: meson
+    meson-parameters:
+      - --prefix=/
+    source: .
+    build-packages:
+      - meson


### PR DESCRIPTION
This is the first update required to support core24:
- Adds the core24 image and test directory
- Updates the image/qemu vesion combination for jammy/core22 as there is a known bug, see: [LP2096782](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2096782)
- Removes the squashfs workaround as the issue linked has been solved and the fix is released (also: it breaks core24 builds)
- Updates the maintainer in authors so that the old maintainer doesn't receive emails about this resurrected fork

This also removes the following:
- Removes podman support as it wont be supported for now
- Removes i386 as it wont be supported for now
- ~~Removes amd64 as I currently see no point in cross building for amd64~~ Re added, makes sense for VM builds of core16

Passing tests: (tests are failing on the pr because I cancelled them to save some runner time and allow my other repo to get the runners)
- Build and test: https://github.com/Hook25/snapcraft-container/actions/runs/13262437308/job/37022637801 
- Buld and push: https://github.com/Hook25/snapcraft-container/actions/runs/13263306462/job/37024600978
