### PR TITLE
Add support for riscv64 for core24 and core22

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -31,10 +31,10 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
         - base: core22
           base_os: jammy
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
         - base: core24
           base_os: noble
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Generate Build Matrix
       id: matrix
       run: |
-        PLATFORMS=(linux/amd64 linux/arm/v7 linux/arm64) # linux/s390x)
+        PLATFORMS=(linux/amd64 linux/arm/v7 linux/arm64 linux/riscv64) # linux/s390x)
         BASES=(core core18 core20 core22 core24)
 
         BUILD_MATRIX=
@@ -52,6 +52,8 @@ jobs:
           esac
 
           for platform in ${PLATFORMS[@]}; do
+            # only build risv64 for core24
+            [ "$platform" = "linux/riscv64" ] && [ "$base" != "core24" ] && continue
             [ "$platform" = "linux/386"  ] &&   [ "$base" != "core" ] && [ "$base" != "core18" ]   && continue
             [ "$platform" = "linux/s390" ] && ( [ "$base"  = "core" ] || [ "$base"  = "core18" ] ) && continue
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
           for platform in ${PLATFORMS[@]}; do
             # only build risv64 for core24
-            [ "$platform" = "linux/riscv64" ] && [ "$base" != "core24" ] && continue
+            [ "$platform" = "linux/riscv64" ] && [ "$base" != "core24" ] && [ "$base" != "core22" ] && continue
             [ "$platform" = "linux/386"  ] &&   [ "$base" != "core" ] && [ "$base" != "core18" ]   && continue
             [ "$platform" = "linux/s390" ] && ( [ "$base"  = "core" ] || [ "$base"  = "core18" ] ) && continue
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           esac
 
           for platform in ${PLATFORMS[@]}; do
-            # only build risv64 for core24
+            # only build risv64 for core24 and core22
             [ "$platform" = "linux/riscv64" ] && [ "$base" != "core24" ] && [ "$base" != "core22" ] && continue
             [ "$platform" = "linux/386"  ] &&   [ "$base" != "core" ] && [ "$base" != "core18" ]   && continue
             [ "$platform" = "linux/s390" ] && ( [ "$base"  = "core" ] || [ "$base"  = "core18" ] ) && continue


### PR DESCRIPTION
This adds `riscv64` support for `core24` and `core22`