### PR TITLE
Force install snap version of snapd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,14 @@ jobs:
           channel=latest/stable
           runner=ubuntu-latest
 
+          # use focal runner (which is a SHR) to run core builds as they
+          # require xenial lxd which requires cgroup v1
           case $base in
             core)
               os=xenial
               channel=4.x/stable
               experimenal=true
-              runner=ubuntu-20.04
+              runner=focal
               ;;
             core18)
               os=bionic

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,8 @@ $CMD $args
 EOF
 chmod +x /usr/local/bin/docker_commandline.sh
 
+# here we force install/refresh snapd as the deb version may be outdated and
+# not support installing the snapcraft base anymore
 cat > /etc/systemd/system/docker-exec.service <<EOF
 [Unit]
 Description=Docker commandline
@@ -70,7 +72,7 @@ Wants=snapd.seeded.service
 After=snapd.service snapd.socket snapd.seeded.service
 
 [Service]
-ExecStartPre=/bin/bash -c '/usr/bin/snap install snapcraft --classic --channel $USE_SNAPCRAFT_CHANNEL < /dev/null'
+ExecStartPre=/bin/bash -c '/usr/bin/snap install snapd || /usr/bin/snap refresh snapd && /usr/bin/snap install snapcraft --classic --channel $USE_SNAPCRAFT_CHANNEL < /dev/null'
 ExecStart=/usr/local/bin/docker_commandline.sh
 Environment="SNAPPY_LAUNCHER_INSIDE_TESTS=true"
 Environment="LANG=C.UTF-8"


### PR DESCRIPTION
Snapd in the main armhf archive is no longer compatible with core18, so it fails to install which internally makes snapcraft fail to install. Given that 18.04 is ESM now, we need to get the update not from the archive but actually from the snap store, as that is the only source where it was backported.