### PR TITLE
Update version for focal because 9.x doesn't support it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,15 @@ jobs:
               ;;
             core20)
               os=focal
+              channel=8.x/stable
               ;;
             core22)
               os=jammy
+              channel=8.x/stable
               ;;
             core24)
               os=noble
+              channel=9.x/stable
               ;;
           esac
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,8 +27,11 @@ if [ -z "$USE_SNAPCRAFT_CHANNEL" ]; then
             # core18/bionic disabled in snapcraft 6+.
             USE_SNAPCRAFT_CHANNEL="5.x/stable"
             ;;
+        focal)
+            USE_SNAPCRAFT_CHANNEL="8.x/stable"
+            ;;
         *)
-            USE_SNAPCRAFT_CHANNEL="latest/stable"
+            USE_SNAPCRAFT_CHANNEL="9.x/stable"
             ;;
     esac
 else


### PR DESCRIPTION
This also pins all others to 9.x so that we don't run into this problem next time, we update the version when necessary rather than breaking till update like now