### PR TITLE
Add permissions to push to package archive

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,4 +1,9 @@
 name: Build Container Images
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 on:
   schedule:


### PR DESCRIPTION
Add permissions to push to package archive else the build workflow fails with the following error:
```
failed to push ghcr.io/canonical/snapcraft-container:core-master: denied: installation not allowed to Write organization package
```
